### PR TITLE
pbcoreDescriptionDocument_publicationHistory

### DIFF
--- a/pbcore-2-ebucore.xsl
+++ b/pbcore-2-ebucore.xsl
@@ -45,14 +45,6 @@
                     <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">
                         <xsl:value-of select="pbcore:pbcoreTitle[@titleType='Episode']"/>
                     </rdfs:label>
-                    <ebucore:hasPublicationHistory>
-                        <ebucore:hasPublicationEvent>
-                            <ebucore:publishedStarDateTime>
-                                <xsl:value-of select="pbcore:pbcoreAssetDate[@dateType='broadcast']"
-                                />
-                            </ebucore:publishedStarDateTime>
-                        </ebucore:hasPublicationEvent>
-                    </ebucore:hasPublicationHistory>
                     <pbcore:episodeTitle>
                         <xsl:value-of select="pbcore:pbcoreTitle[@titleType='Episode']"/>
                     </pbcore:episodeTitle>


### PR DESCRIPTION
removed publicationHistory/publicationEvent to Asset. Othe solution proposed in earlier commit
